### PR TITLE
Remove broken link to onebusaway-iphone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # README
 This code has been integrated into the [onebusaway-iphone](https://github.com/OneBusAway/onebusaway-iphone) repository, and is thus no longer supported as a standalone project. 
 
-[Commit history](https://github.com/OneBusAway/onebusaway-iphone-common/commits/master) for this project has been left in tact. However, to see the most recent updates to this library, please see the [main project](https://github.com/OneBusAway/onebusaway-iphone/tree/develop/Libraries/aaronbrethorst-onebusaway-iphone-common-fa9a21b).
+[Commit history](https://github.com/OneBusAway/onebusaway-iphone-common/commits/master) for this project has been left intact in case it needs to be referenced in the future.


### PR DESCRIPTION
This link was broken in the Readme, so this patch removes it.  As far as I can tell there isn't a direct link to  a separate onebusaway-iphone-common library in OBA iOS at this point, so its better just to remove that portion of Readme.

@aaronbrethorst if there is a direct link to onebusaway-iphone-common library in OBA iOS then feel free to replace my patch with the correct link.